### PR TITLE
Export strain page URLs and flatten interop-query responses

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,6 +18,7 @@ import utils
 import uuid
 from datetime import timedelta
 import shutil
+from urllib.parse import urlencode
 import zipfile
 import io
 import logging
@@ -1565,6 +1566,34 @@ def _growth_row_to_dict(row):
         d["signal_data"] = [float(v) for v in d["signal_data"]]
     return d
 
+def _build_strain_urls(strain_id):
+    """Build a list of /mainstraindata URLs for every plate belonging to a strain."""
+    rows = (db.session.query(
+                KineticData.plateid,
+                KineticData.specie,
+                KineticData.plate,
+                KineticData.media,
+                KineticData.strain,
+                KineticData.metadata_mods,
+            )
+            .filter_by(strainid=strain_id)
+            .distinct()
+            .all())
+
+    urls = []
+    for r in rows:
+        params = urlencode({
+            "pltid":    r.plateid,
+            "strn":     r.specie,
+            "plate":    r.plate,
+            "media":    r.media or "",
+            "strid":    strain_id,
+            "metadata": r.metadata_mods or "",
+            "strain":   r.strain or "",
+        })
+        urls.append(f"/mainstraindata?{params}")
+    return urls
+
 @app.route("/interop-query/query-by-strain", methods=["POST"])
 @cross_origin()
 def query_by_strain():
@@ -1599,6 +1628,7 @@ def query_by_strain():
             if not plate_ids:
                 entries.append({
                     "strainid": strain_id,
+                    "urls":     [],
                     "kinethicdata": [],
                     "traitdata":   []
                 })
@@ -1616,6 +1646,7 @@ def query_by_strain():
 
             entries.append({
                 "strainid": strain_id,
+                "urls":     _build_strain_urls(strain_id),
                 "kinethicdata": [_row_to_dict(r) for r in kin_rows],
                 "traitdata":    [_row_to_dict(r) for r in trait_rows],
             })
@@ -1649,8 +1680,11 @@ def get_all_strains():
     
     try:
         strain_ids = db.session.query(KineticData.strainid).distinct().all()
-        
-        strains = [strain_id for (strain_id,) in strain_ids]
+
+        strains = [
+            {"strain": strain_id, "urls": _build_strain_urls(strain_id)}
+            for (strain_id,) in strain_ids
+        ]
 
         return jsonify({"strains": strains}), 200
 

--- a/app.py
+++ b/app.py
@@ -1566,17 +1566,17 @@ def _growth_row_to_dict(row):
         d["signal_data"] = [float(v) for v in d["signal_data"]]
     return d
 
-def _build_strain_entries(strain_id):
+def _build_strain_entries(strain_name):
     """Return a flat list of dicts — one per (strain, plate) combo — with full params and url."""
     rows = (db.session.query(
                 KineticData.plateid,
+                KineticData.strainid,
                 KineticData.specie,
                 KineticData.plate,
                 KineticData.media,
-                KineticData.strain,
                 KineticData.metadata_mods,
             )
-            .filter_by(strainid=strain_id)
+            .filter_by(strain=strain_name)
             .distinct()
             .all())
 
@@ -1587,12 +1587,12 @@ def _build_strain_entries(strain_id):
             "strn":     r.specie,
             "plate":    r.plate,
             "media":    r.media or "",
-            "strid":    strain_id,
+            "strid":    r.strainid,
             "metadata": r.metadata_mods or "",
-            "strain":   r.strain or "",
+            "strain":   strain_name,
         })
         entries.append({
-            "strain":   strain_id,
+            "strain":   strain_name,
             "plateid":  r.plateid,
             "plate":    r.plate,
             "specie":   r.specie,
@@ -1622,47 +1622,44 @@ def query_by_strain():
 
         entries = []
 
-        unique_plate_ids = set()
-        for strain_id in ids:
-            plate_ids = {p for (p,) in (
+        for strain_name in ids:
+            plate_ids = (
                 db.session.query(KineticData.plateid)
-                          .filter_by(strainid=strain_id)
+                          .filter_by(strain=strain_name)
                           .distinct()
-            )}
+                          .all()
+            )
 
-            unique_plate_ids |= plate_ids
-
-            # If a strain never occurs, return empty lists instead of error.
             if not plate_ids:
-                entries.append({
-                    "strainid": strain_id,
-                    "urls":     [],
-                    "kinethicdata": [],
-                    "traitdata":   []
-                })
                 continue
 
-            kin_rows = (KineticData.query
-                        .filter_by(strainid=strain_id)
-                        .filter(KineticData.plateid.in_(plate_ids))
-                        .all())
+            # Build URL lookup for this strain
+            url_entries = _build_strain_entries(strain_name)
+            url_map = {e["plateid"]: e["url"] for e in url_entries}
 
-            trait_rows = (TraitData.query
-                          .filter_by(strainid=strain_id)
-                          .filter(TraitData.plateid.in_(plate_ids))
-                          .all())
+            for (plate_id,) in plate_ids:
+                kin_rows = (KineticData.query
+                            .filter_by(strain=strain_name, plateid=plate_id)
+                            .all())
 
-            entries.append({
-                "strainid": strain_id,
-                "urls":     _build_strain_urls(strain_id),
-                "kinethicdata": [_row_to_dict(r) for r in kin_rows],
-                "traitdata":    [_row_to_dict(r) for r in trait_rows],
-            })
+                trait_rows = (TraitData.query
+                              .filter_by(strain=strain_name, plateid=plate_id)
+                              .all())
 
+                first = kin_rows[0] if kin_rows else None
+                entries.append({
+                    "url":          url_map.get(plate_id, ""),
+                    "plateid":      plate_id,
+                    "strain":       strain_name,
+                    "plate":        first.plate if first else "",
+                    "specie":       first.specie if first else "",
+                    "media":        first.media if first else "",
+                    "metadata":     first.metadata_mods if first else "",
+                    "kinethicdata": [_row_to_dict(r) for r in kin_rows],
+                    "traitdata":    [_row_to_dict(r) for r in trait_rows],
+                })
 
-        return jsonify({
-            "entries": entries,
-        }), 200
+        return jsonify({"entries": entries}), 200
 
     except Exception as exc:
         logger.exception("Error in query_by_strain")
@@ -1679,11 +1676,11 @@ def get_all_strains():
     logger.info("get all strains")
     
     try:
-        strain_ids = db.session.query(KineticData.strainid).distinct().all()
+        strain_names = db.session.query(KineticData.strain).distinct().all()
 
         strains = []
-        for (strain_id,) in strain_ids:
-            strains.extend(_build_strain_entries(strain_id))
+        for (strain_name,) in strain_names:
+            strains.extend(_build_strain_entries(strain_name))
 
         return jsonify({"strains": strains}), 200
 

--- a/app.py
+++ b/app.py
@@ -1659,17 +1659,9 @@ def query_by_strain():
                 "traitdata":    [_row_to_dict(r) for r in trait_rows],
             })
 
-        if unique_plate_ids:
-            growth_rows = (GrowthData.query
-                           .filter(GrowthData.plateid.in_(unique_plate_ids))
-                           .all())
-            plates_payload = [_growth_row_to_dict(g) for g in growth_rows]
-        else:
-            plates_payload = []
 
         return jsonify({
             "entries": entries,
-            "plates":   plates_payload
         }), 200
 
     except Exception as exc:

--- a/app.py
+++ b/app.py
@@ -1559,12 +1559,6 @@ def _row_to_dict(row):
     """Generic SQLAlchemy → dict (all simple columns)."""
     return {c.name: getattr(row, c.name) for c in row.__table__.columns}
 
-def _growth_row_to_dict(row):
-    """GrowthData → dict, making signal_data JSON-safe."""
-    d = _row_to_dict(row)
-    if isinstance(d.get("signal_data"), list):
-        d["signal_data"] = [float(v) for v in d["signal_data"]]
-    return d
 
 def _build_strain_entries(strain_name):
     """Return a flat list of dicts — one per (strain, plate) combo — with full params and url."""
@@ -1606,10 +1600,12 @@ def _build_strain_entries(strain_name):
 @cross_origin()
 def query_by_strain():
     """
-    POST body: {"ids": ["S1", "S2", ...]}
-    Returns, for each strain ID, all KineticData and TraitData rows
-    whose (strainid, plate) match that strain and any plate used
-    by that strain.  The plate list is gathered once from KineticData.
+    POST body: {"ids": ["strainA", "strainB", ...]}
+    Returns, for each strain name, all KineticData and TraitData rows
+    grouped by experiment (plateid). Each entry includes the
+    mainstraindata URL for that experiment.
+    If a strain has no data, a single entry with url=None and empty
+    lists is returned.
     """
     logger.info("query by strain")
 
@@ -1617,44 +1613,34 @@ def query_by_strain():
         payload = request.get_json()
         ids = _parse_ids(payload, "ids")
 
-        def _row_to_dict(row):
-            return {c.name: getattr(row, c.name) for c in row.__table__.columns}
-
         entries = []
 
         for strain_name in ids:
-            plate_ids = (
-                db.session.query(KineticData.plateid)
-                          .filter_by(strain=strain_name)
-                          .distinct()
-                          .all()
-            )
+            url_entries = _build_strain_entries(strain_name)
 
-            if not plate_ids:
+            if not url_entries:
+                entries.append({
+                    "url":          None,
+                    "strain":       strain_name,
+                    "plateid":      None,
+                    "kinethicdata": [],
+                    "traitdata":    [],
+                })
                 continue
 
-            # Build URL lookup for this strain
-            url_entries = _build_strain_entries(strain_name)
-            url_map = {e["plateid"]: e["url"] for e in url_entries}
-
-            for (plate_id,) in plate_ids:
+            for ue in url_entries:
                 kin_rows = (KineticData.query
-                            .filter_by(strain=strain_name, plateid=plate_id)
+                            .filter_by(strain=strain_name, plateid=ue["plateid"])
                             .all())
 
                 trait_rows = (TraitData.query
-                              .filter_by(strain=strain_name, plateid=plate_id)
+                              .filter_by(strain=strain_name, plateid=ue["plateid"])
                               .all())
 
-                first = kin_rows[0] if kin_rows else None
                 entries.append({
-                    "url":          url_map.get(plate_id, ""),
-                    "plateid":      plate_id,
-                    "strain":       strain_name,
-                    "plate":        first.plate if first else "",
-                    "specie":       first.specie if first else "",
-                    "media":        first.media if first else "",
-                    "metadata":     first.metadata_mods if first else "",
+                    "strain":       ue["strain"],
+                    "plateid":      ue["plateid"],
+                    "url":          ue["url"],
                     "kinethicdata": [_row_to_dict(r) for r in kin_rows],
                     "traitdata":    [_row_to_dict(r) for r in trait_rows],
                 })

--- a/app.py
+++ b/app.py
@@ -1566,8 +1566,8 @@ def _growth_row_to_dict(row):
         d["signal_data"] = [float(v) for v in d["signal_data"]]
     return d
 
-def _build_strain_urls(strain_id):
-    """Build a list of /mainstraindata URLs for every plate belonging to a strain."""
+def _build_strain_entries(strain_id):
+    """Return a flat list of dicts — one per (strain, plate) combo — with full params and url."""
     rows = (db.session.query(
                 KineticData.plateid,
                 KineticData.specie,
@@ -1580,7 +1580,7 @@ def _build_strain_urls(strain_id):
             .distinct()
             .all())
 
-    urls = []
+    entries = []
     for r in rows:
         params = urlencode({
             "pltid":    r.plateid,
@@ -1591,8 +1591,16 @@ def _build_strain_urls(strain_id):
             "metadata": r.metadata_mods or "",
             "strain":   r.strain or "",
         })
-        urls.append(f"/mainstraindata?{params}")
-    return urls
+        entries.append({
+            "strain":   strain_id,
+            "plateid":  r.plateid,
+            "plate":    r.plate,
+            "specie":   r.specie,
+            "media":    r.media or "",
+            "metadata": r.metadata_mods or "",
+            "url":      f"/mainstraindata?{params}",
+        })
+    return entries
 
 @app.route("/interop-query/query-by-strain", methods=["POST"])
 @cross_origin()
@@ -1681,10 +1689,9 @@ def get_all_strains():
     try:
         strain_ids = db.session.query(KineticData.strainid).distinct().all()
 
-        strains = [
-            {"strain": strain_id, "urls": _build_strain_urls(strain_id)}
-            for (strain_id,) in strain_ids
-        ]
+        strains = []
+        for (strain_id,) in strain_ids:
+            strains.extend(_build_strain_entries(strain_id))
 
         return jsonify({"strains": strains}), 200
 


### PR DESCRIPTION
- Add _build_strain_entries helper to generate mainstraindata URLs with full query parameters
- GET /interop-query/strains returns flat list with one entry per experiment, each with its URL
- POST /interop-query/query-by-strain accepts strain names, returns flat entries per experiment with plate_id, URL, KineticData and TraitData (GrowthData removed)